### PR TITLE
Fix compatibility with ::Set

### DIFF
--- a/lib/rspec-set.rb
+++ b/lib/rspec-set.rb
@@ -2,7 +2,7 @@ require "version"
 
 module RSpec
   module Core
-    module Set
+    module RSpecSet
       module ClassMethods
         # Set @variable_name in a before(:all) block and give access to it
         # via let(:variable_name)
@@ -47,10 +47,10 @@ module RSpec
       def self.included(mod) # :nodoc:
         mod.extend ClassMethods
       end
-    end # Set
+    end # RSpecSet
 
     class ExampleGroup
-      include Set
+      include RSpecSet
     end # ExampleGroup
 
   end # Core

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,5 +1,5 @@
 module Rspec
-  module Set
+  module RSpecSet
     VERSION = "0.1.2"
   end
 end

--- a/rspec-set.gemspec
+++ b/rspec-set.gemspec
@@ -5,7 +5,7 @@ require 'version'
 
 Gem::Specification.new do |spec|
   spec.name          = "rspec-set"
-  spec.version       = Rspec::Set::VERSION
+  spec.version       = Rspec::RSpecSet::VERSION
   spec.authors       = ["Philippe Creux"]
   spec.email         = ["pcreux@gmail.com"]
   spec.description   = "#set(), speed-up your specs"


### PR DESCRIPTION
Hi - I was running into problems with a few places in RSpec::Core that call `Set.new`, expecting "Set" to refer to the regular stdlib `::Set`.  WDYT to renaming rspec-set's module?
