### PR TITLE
Bump rake to 11.0.1 or higher

### DIFF
--- a/rspec-set.gemspec
+++ b/rspec-set.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.email         = ["pcreux@gmail.com"]
   spec.description   = "#set(), speed-up your specs"
   spec.summary       = "#set() is a helper for RSpec which setup active record
-                        objects before all tests and restore them to there original state 
+                        objects before all tests and restore them to there original state
                         before each test"
   spec.homepage      = "http://github.com/pcreux/rspec-set"
   spec.license       = "MIT"
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "rspec", "~> 2.14.1"
+  spec.add_development_dependency "rspec"
   spec.add_development_dependency "database_cleaner"
   spec.add_development_dependency "activerecord"
   spec.add_development_dependency "sqlite3"


### PR DESCRIPTION
While I would've wanted a bit lower, I figured if people are upgrading
this gem they would be running on a somewhat up to date version of rake
already, and its only a development dependency.

Rake 11.0.0 was yanked, hence the 11.0.1.